### PR TITLE
fix: CloudFormation errors #177

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,17 @@ Current features:
  * VPC with public subnet  and security groups to restrict access by IP
  * S3 bucket for fast backup/restore of your Steam Library to/from instance storage using [restic]
 
-## Howto
+## How-to
 
 Show template:
 
     ./deploy.py --print-only
 
-Create or update stack:
+Deploying the CloudFormation stack the first time requires a keypair (in this case `ec2-gaming`) to exist:
+
+    ./deploy.py --keypair ec2-gaming
+
+When updating CloudFormation stack, passing parameters is not required and existing settings remain untouched:
 
     ./deploy.py
 
@@ -29,7 +33,7 @@ Launch on-demand instance:
 
     aws ec2 run-instances --launch-template LaunchTemplateName=jammy-sunshine-on-demand,Version=\$Latest
 
-Update IP address in security groups:
+By default, access to the EC2 instance is restriced. To update ane set the whitelisted IP address to the IP address of the caller:
 
     ./update-ip.py
 

--- a/deploy.py
+++ b/deploy.py
@@ -10,12 +10,15 @@ import boto3
 from jinja2 import Template
 
 STACK_NAME = "jammy-sunshine"
+DEFAULT_KEYPAIR = "ec2-gaming"
+INITIAL_WHITELISTED_IP = "127.0.0.1/32"
 
 
 def main():
 
     parser = argparse.ArgumentParser(prog="deploy", epilog="Create or update stack")
-    parser.add_argument("--print-only", action="store_true")
+    parser.add_argument("--print-only", help="Print CF template but do not deploy", action="store_true")
+    parser.add_argument("--keypair", help=f"Name of EC2 keypair to use, defaults to '{DEFAULT_KEYPAIR}'", default=DEFAULT_KEYPAIR)
 
     args = parser.parse_args()
 
@@ -74,8 +77,8 @@ def main():
             StackName=STACK_NAME,
             TemplateBody=template.render(cloud_config=cloud_config_b64_text_),
             Parameters=[
-                {"ParameterKey": "MyIp", "ParameterValue": "127.0.0.1"},
-                {"ParameterKey": "KeyPair", "ParameterValue": "ec2-gaming"},
+                {"ParameterKey": "MyIp", "ParameterValue": INITIAL_WHITELISTED_IP},
+                {"ParameterKey": "KeyPair", "ParameterValue": args.keypair},
             ],
             Capabilities=["CAPABILITY_NAMED_IAM"],
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
-[tool.ruff]
+[tool.ruff.lint]
 ignore = ["E501"]
 
-[tool.ruff.flake8-quotes]
+[tool.ruff.lint.flake8-quotes]
 inline-quotes = "double"
 multiline-quotes = "double"
 docstring-quotes = "double"
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 7


### PR DESCRIPTION
 - improved docs
 - allows passing a customer EC2 key pair when deploying via CLI
 - set initial whitelisted IP to 127.0.0.1/32
 - fixed deprecated ruff settings in pyproject.toml